### PR TITLE
Fix query parameter key

### DIFF
--- a/goweather.go
+++ b/goweather.go
@@ -17,7 +17,7 @@ func main() {
 
 	arg := os.Args[1]
 
-	url := fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?q=%s&units=imperial", url.QueryEscape(arg))
+	url := fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?zip=%s&units=imperial", url.QueryEscape(arg))
 
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
Was wondering why my weather data was off and did some looking into the API documentation. The `q` param looks for city name instead of zip code. Somehow my zip code matched a city in Estonia.

I thought that we could also check the type and choose the right query param based on user input. I have a big refactor branch in the works with that functionality included but here's the gist of it:

``` go
    // Check if argument can be parsed into an integer which
    // tells us that we probably have a zip code, could add length
    // checking to be even more precise. We then check if it's not
    // empty and assume it's a city name and if it is empty we exit.
    _, err := strconv.Atoi(os.Args[1])
    if err == nil {
        key = "zip"
    } else if val != "" {
        key = "q"
    } else {
        help()
        os.Exit(3)
    }
```
